### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cloud4rpi
 pycodestyle
 pylint
 pyfakefs
+RPi.GPIO


### PR DESCRIPTION
add RPi.GPIO module to prevent

```
Traceback (most recent call last):
  File "control.py", line 9, in <module>
    import RPi.GPIO as GPIO  # pylint: disable=F0401
ModuleNotFoundError: No module named 'RPi'
```

(at least on raspberry pi v1)